### PR TITLE
Fix crush on iOS 7

### DIFF
--- a/ios/gcm/GcmExample/AppDelegate.m
+++ b/ios/gcm/GcmExample/AppDelegate.m
@@ -44,12 +44,20 @@ NSString *const SubscriptionTopic = @"/topics/global";
   _gcmSenderID = [[[GGLContext sharedInstance] configuration] gcmSenderID];
   // [END_EXCLUDE]
   // Register for remote notifications
-  UIUserNotificationType allNotificationTypes =
-      (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
-  UIUserNotificationSettings *settings =
-      [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
-  [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-  [[UIApplication sharedApplication] registerForRemoteNotifications];
+  if(floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1){
+    //iOS 7.1 or earlier
+    UIRemoteNotificationType allNotificationTypes =
+        (UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeBadge);
+    [application registerForRemoteNotificationTypes:allNotificationTypes];
+  }else{
+    //iOS 8 or later
+    UIUserNotificationType allNotificationTypes =
+        (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
+    UIUserNotificationSettings *settings =
+        [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
+    [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
+  }
   // [END register_for_remote_notifications]
   // [START start_gcm_service]
   [[GCMService sharedInstance] startWithConfig:[GCMConfig defaultConfig]];

--- a/ios/gcm/GcmExample/ViewController.m
+++ b/ios/gcm/GcmExample/ViewController.m
@@ -53,17 +53,29 @@
 }
 
 - (void)showAlert:(NSString *)title withMessage:(NSString *) message{
-  UIAlertController *alert =
-      [UIAlertController alertControllerWithTitle:title
-                                          message:message
-                                   preferredStyle:UIAlertControllerStyleAlert];
+  if(floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1){
+    //iOS 7.1 or earlier
+    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title
+                                                    message:message
+                                                   delegate:nil
+                                          cancelButtonTitle:@"Dismiss"
+                                          otherButtonTitles:nil];
+    [alert show];
 
-  UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:@"Dismiss"
-                                                          style:UIAlertActionStyleDestructive
-                                                        handler:nil];
+  }else{
+    //iOS 8 or later
+    UIAlertController *alert =
+        [UIAlertController alertControllerWithTitle:title
+                                            message:message
+                                     preferredStyle:UIAlertControllerStyleAlert];
 
-  [alert addAction:dismissAction];
-  [self presentViewController:alert animated:YES completion:nil];
+    UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:@"Dismiss"
+                                                            style:UIAlertActionStyleDestructive
+                                                          handler:nil];
+
+    [alert addAction:dismissAction];
+    [self presentViewController:alert animated:YES completion:nil];
+  }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
If running on iOS 7.1 or earlier

- Not use [UIApplication registerUserNotificationSettings:]
- Not use UIAlertController