### PR TITLE
bump library and SDK versions

### DIFF
--- a/android/gcm/app/build.gradle
+++ b/android/gcm/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.0"
 
     defaultConfig {
         applicationId "gcm.play.android.samples.com.gcmquickstart"
         minSdkVersion 9
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
 
@@ -27,12 +27,12 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.gms:play-services-gcm:7.5.+'
+    compile 'com.google.android.gms:play-services-gcm:7.8.+'
 
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:23.0.0'
 
     // Testing dependencies
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.1'
     androidTestCompile 'com.android.support.test:runner:0.2'
-    androidTestCompile 'com.android.support:support-annotations:22.1.1'
+    androidTestCompile 'com.android.support:support-annotations:23.0.0'
 }

--- a/android/gcm/build.gradle
+++ b/android/gcm/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
         classpath 'com.google.gms:google-services:1.3.0-beta1'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
bump library and SDK versions to make building possible on freshly installed AS — the API 22 SDK is not installed by default and new apps should target API 23 anyway