### PR TITLE
Clarifying how to get Sender ID value from generated config file.

### DIFF
--- a/android/gcm/app/src/main/java/gcm/play/android/samples/com/gcmquickstart/RegistrationIntentService.java
+++ b/android/gcm/app/src/main/java/gcm/play/android/samples/com/gcmquickstart/RegistrationIntentService.java
@@ -48,6 +48,8 @@ public class RegistrationIntentService extends IntentService {
             // are local.
             // [START get_token]
             InstanceID instanceID = InstanceID.getInstance(this);
+            // SenderID value is typically derived from google-services.json.
+            // See https://developers.google.com/cloud-messaging/android/start for details on this file.
             String token = instanceID.getToken(getString(R.string.gcm_defaultSenderId),
                     GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
             // [END get_token]

--- a/android/gcm/app/src/main/java/gcm/play/android/samples/com/gcmquickstart/RegistrationIntentService.java
+++ b/android/gcm/app/src/main/java/gcm/play/android/samples/com/gcmquickstart/RegistrationIntentService.java
@@ -48,7 +48,7 @@ public class RegistrationIntentService extends IntentService {
             // are local.
             // [START get_token]
             InstanceID instanceID = InstanceID.getInstance(this);
-            // SenderID value is typically derived from google-services.json.
+            // R.string.gcm_defaultSenderId (the Sender ID) is typically derived from google-services.json.
             // See https://developers.google.com/cloud-messaging/android/start for details on this file.
             String token = instanceID.getToken(getString(R.string.gcm_defaultSenderId),
                     GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);


### PR DESCRIPTION
Adding a comment to clarify where to find the Sender ID to use here.  

This is in response to a bug report from a user who was confused to see a warning flag in the IDE and no string value for this in strings.xml.

I tried to keep the comment to two lines.  