### PR TITLE
Add GcmSender disclaimer

### DIFF
--- a/android/gcm/README.md
+++ b/android/gcm/README.md
@@ -23,6 +23,14 @@ Getting Started
 - A notification containing the GCM message should be displayed on the
   device.
 
+NOTE
+----
+
+The GcmSender module in this project is emulating a server for the purposes of
+this sample, but it's not meant to serve as an example for a production app
+server. For information on GCM server implementaion
+see [About GCM Connection Server](https://developers.google.com/cloud-messaging/server)
+
 Screenshots
 -----------
 ![Screenshot](app/src/main/gcm-sample.png)

--- a/android/gcm/gcmsender/src/main/java/gcm/play/android/samples/com/gcmsender/GcmSender.java
+++ b/android/gcm/gcmsender/src/main/java/gcm/play/android/samples/com/gcmsender/GcmSender.java
@@ -26,6 +26,12 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+// NOTE:
+// This class emulates a server for the purposes of this sample,
+// but it's not meant to serve as an example for a production app server.
+// This class should also not be included in the client (Android) applicaiton
+// since it includes the server's API key. For information on GCM server
+// implementaion see: https://developers.google.com/cloud-messaging/server
 public class GcmSender {
 
     public static final String API_KEY = "API_KEY";


### PR DESCRIPTION
Add notes that inform users that GcmSender is included in this sample to enable easy testing of GCM and should not be used in production applications.