### PR TITLE
Fix typo and remove unused import

### DIFF
--- a/android/gcm/gcmsender/src/main/java/gcm/play/android/samples/com/gcmsender/GcmSender.java
+++ b/android/gcm/gcmsender/src/main/java/gcm/play/android/samples/com/gcmsender/GcmSender.java
@@ -17,7 +17,6 @@
 package gcm.play.android.samples.com.gcmsender;
 
 import org.apache.commons.io.IOUtils;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
@@ -31,7 +30,7 @@ import java.net.URL;
 // but it's not meant to serve as an example for a production app server.
 // This class should also not be included in the client (Android) applicaiton
 // since it includes the server's API key. For information on GCM server
-// implementaion see: https://developers.google.com/cloud-messaging/server
+// implementation see: https://developers.google.com/cloud-messaging/server
 public class GcmSender {
 
     public static final String API_KEY = "API_KEY";


### PR DESCRIPTION
Also the doc should be updated in
https://developers.google.com/cloud-messaging/android/start 
> Run the sample
> First, make sure your API key is provided as the value of API_KEY in line 36 of GcmSender.java