### PR TITLE
Added RegistrationIntentService to the Manifest because without it gc…

### DIFF
--- a/android/gcm/app/src/main/AndroidManifest.xml
+++ b/android/gcm/app/src/main/AndroidManifest.xml
@@ -43,6 +43,11 @@
             </intent-filter>
         </service>
         <!-- [END gcm_listener] -->
+		<!-- Included Intent Service used to get gcm registration id-->
+		<service
+            android:name="gcm.play.android.samples.com.gcmquickstart.RegistrationIntentService"
+            android:exported="false">
+        </service>
         <!-- [START instanceId_listener] -->
         <service
             android:name="gcm.play.android.samples.com.gcmquickstart.MyInstanceIDListenerService"


### PR DESCRIPTION
…m registration id will not be retrieved by the RegistrationIntentService because the app will not be able to navigate to the service using intent.