### PR TITLE
Update Android Gradle plugin to 2.3.0

### DIFF
--- a/android/analytics/build.gradle
+++ b/android/analytics/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/gcm/build.gradle
+++ b/android/gcm/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/signin/build.gradle
+++ b/android/signin/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
The stable version of Android Studio 2.3.0 and the matching Android Gradle plugin `2.3.0` were released today.

https://android-developers.googleblog.com/2017/03/android-studio-2-3.html
