### PR TITLE
Resolves ProgressDialog issues

### DIFF
--- a/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivity.java
+++ b/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivity.java
@@ -100,8 +100,7 @@ public class SignInActivity extends AppCompatActivity implements
     @Override
     protected void onResume() {
         super.onResume();
-        hideProgressDialog();//To hide {@link ProgressDialog} which comes into view unnecessarily,
-        // after successful login.
+        hideProgressDialog();
     }
 
     // [START onActivityResult]
@@ -178,8 +177,7 @@ public class SignInActivity extends AppCompatActivity implements
     protected void onStop() {
         super.onStop();
         if (mProgressDialog != null) {
-            mProgressDialog.dismiss();// to avoid  WindowLeaked issue. This happens when a hidden
-            // {@link ProgressDialog} is present but activity is being destroyed.
+            mProgressDialog.dismiss();
         }
     }
 

--- a/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivity.java
+++ b/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivity.java
@@ -97,6 +97,13 @@ public class SignInActivity extends AppCompatActivity implements
         }
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        hideProgressDialog();//To hide {@link ProgressDialog} which comes into view unnecessarily,
+        // after successful login.
+    }
+
     // [START onActivityResult]
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -165,6 +172,15 @@ public class SignInActivity extends AppCompatActivity implements
         // An unresolvable error has occurred and Google APIs (including Sign-In) will not
         // be available.
         Log.d(TAG, "onConnectionFailed:" + connectionResult);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (mProgressDialog != null) {
+            mProgressDialog.dismiss();// to avoid  WindowLeaked issue. This happens when a hidden
+            // {@link ProgressDialog} is present but activity is being destroyed.
+        }
     }
 
     private void showProgressDialog() {

--- a/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivityWithDrive.java
+++ b/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivityWithDrive.java
@@ -107,6 +107,13 @@ public class SignInActivityWithDrive extends AppCompatActivity implements
         }
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        hideProgressDialog();//To hide {@link ProgressDialog} which comes into view unnecessarily,
+        // after successful login.
+    }
+
     // [START onActivityResult]
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -175,6 +182,15 @@ public class SignInActivityWithDrive extends AppCompatActivity implements
         // An unresolvable error has occurred and Google APIs (including Sign-In) will not
         // be available.
         Log.d(TAG, "onConnectionFailed:" + connectionResult);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (mProgressDialog != null) {
+            mProgressDialog.dismiss();// to avoid  WindowLeaked issue. This happens when a hidden
+            // {@link ProgressDialog} is present but activity is being destroyed.
+        }
     }
 
     private void showProgressDialog() {

--- a/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivityWithDrive.java
+++ b/android/signin/app/src/main/java/com/google/samples/quickstart/signin/SignInActivityWithDrive.java
@@ -110,8 +110,7 @@ public class SignInActivityWithDrive extends AppCompatActivity implements
     @Override
     protected void onResume() {
         super.onResume();
-        hideProgressDialog();//To hide {@link ProgressDialog} which comes into view unnecessarily,
-        // after successful login.
+        hideProgressDialog();
     }
 
     // [START onActivityResult]
@@ -188,8 +187,7 @@ public class SignInActivityWithDrive extends AppCompatActivity implements
     protected void onStop() {
         super.onStop();
         if (mProgressDialog != null) {
-            mProgressDialog.dismiss();// to avoid  WindowLeaked issue. This happens when a hidden
-            // {@link ProgressDialog} is present but activity is being destroyed.
+            mProgressDialog.dismiss();
         }
     }
 


### PR DESCRIPTION
Two activity lifecycle methods are overridden in `SignInActivity `and `SignInActivityWithDrive `activities because they both use and have issues regarding `ProgressDialog`,

- `onResume()` 
When you successfully login after pressing sign-in button and choosing your account, view of above mentioned activities are blocked by indeterminate progress dialog, so we hide it here.

- `onStop()`
As progress dialog is not dismissed anywhere, it generates `android.view.WindowLeaked` error when returning to `ChooserActivity` from above mentioned activities, so we dismiss it here.