### PR TITLE
Solve error "Failed to resolve: ...play-services-gcm:11.6.0"

### DIFF
--- a/android/gcm/build.gradle
+++ b/android/gcm/build.gradle
@@ -18,5 +18,8 @@ allprojects {
     repositories {
         jcenter()
         mavenLocal()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }


### PR DESCRIPTION
If there is no maven `{url "https://maven.google.com}` in the code, 
Android studio will throw the following error:

> Failed to resolve: com.google.android.gms:play-services-gcm:11.6.0