### PR TITLE
Fix link formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,18 @@
 
 ## Contributor License Agreements
 
-We'd love to accept your sample apps and patches! Before we can take them, we 
+We'd love to accept your sample apps and patches! Before we can take them, we
 have to jump a couple of legal hurdles.
 
 Please fill out either the individual or corporate Contributor License Agreement
 (CLA).
 
   * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA]
-    (http://code.google.com/legal/individual-cla-v1.0.html).
+    own the intellectual property, then you'll need to sign an
+    [individual CLA](http://code.google.com/legal/individual-cla-v1.0.html).
   * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA]
-    (http://code.google.com/legal/corporate-cla-v1.0.html).
+    then you'll need to sign a
+    [corporate CLA](http://code.google.com/legal/corporate-cla-v1.0.html).
 
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll be able to
@@ -53,5 +53,5 @@ accept your pull requests.
       this collection of repos.
 1. Submit a request to fork your repo in googlesamples organization.
 1. The repo owner will review your request. If it is approved, the sample will
-   be merged. If it needs additional work, the repo owner will respond with 
+   be merged. If it needs additional work, the repo owner will respond with
    useful comments.


### PR DESCRIPTION
Markdown does not allow spaces between the link name and URL.